### PR TITLE
removed necessity of nmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+# Webstorm IDE
+.idea/*

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var discover = require('./lib/discover')
+var discover = require('./lib/discover' ).discover
   , log = require('debug')('index')
   , EventEmitter = require('events').EventEmitter
 

--- a/lib/discover.js
+++ b/lib/discover.js
@@ -89,7 +89,7 @@ var discover = function (callback) {
                     if (socket) {
                         kettle = socket
                         callback(null, kettle)
-                    } else if(i == 255 && !socket){
+                    } else if(i == 255){
                         debug( 'No IPs to be checked anymore')
                         callback('Kettle not found :{', null);
                     }

--- a/lib/discover.js
+++ b/lib/discover.js
@@ -1,11 +1,10 @@
 'use strict';
 
-var nmap    = require('node-libnmap')
-  , Socket = require('net').Socket
+var Socket = require('net').Socket
   , log       = require('debug')('discover')
   , debug = require('debug')('discover:debug')
+  , ip = require('ip')
 
-var options = {}
 var PORT = 2000
 var HELLO_APP = 'HELLOAPP'
 var HELLO_KETTLE = 'HELLOKETTLE\n'
@@ -36,58 +35,66 @@ var checkForKettle = function(ip, portDetails, callback) {
     })
 }
 
-var performScan = function(ipAddresses, callback) {
-    var opts = {
-        range: ipAddresses,
-        ports: PORT
-    }
-    log('Total of ' + ipAddresses.length + ' ip addresses to check')
-    nmap.nmap('scan', opts, function(error, report) {
-      if (error) {
-          return callback(error)
-      }
-      var counter = 0
-      var kettle = null
-      if (0 === report.length) {
-          return callback('No devices listening on port ' + PORT)
-      }
-      report.forEach(function(item) {
-          checkForKettle(item[0].ip, item[0].ports[0], function(socket) {
-              ++counter
-              if (socket) {
-                kettle = socket
-              }
-              if (counter === ipAddresses.length) {
-                  callback(kettle ? null : 'Kettle not found :(', kettle)
-              }
-          })
-      })
-    })
+/**
+ * This method looks a certain port on a host
+ * and determines if it is open or not
+ * @param port
+ * @param host
+ * @param callback
+ */
+var checkPort = function ( port, host, callback ) {
+    var socket = new Socket(), status = null;
 
+    // Socket connection established, port is open
+    socket.on( 'connect', function () {
+        status = 'open';
+        socket.end();
+    } );
+    socket.setTimeout( 1500 );// If no response, assume port is not listening
+    socket.on( 'timeout', function () {
+        status = 'closed';
+        socket.destroy();
+    } );
+    socket.on( 'error', function ( exception ) {
+        status = 'closed';
+    } );
+    socket.on( 'close', function ( exception ) {
+        callback( null, status, host, port );
+    } );
+
+    socket.connect( port, host );
 }
 
 /**
- * This method loops over local interfaces and finds a list
- * of IP addresses within the same subnet
- */
-var discover = function(callback) {
-  log('Performing discovery')
-  nmap.nmap('discover', options, function(error, networkInterfaces) {
-    if (error) {
-      return callback(error)
+* This method loops over local interfaces and finds a list
+* of IP addresses within the same subnet
+* @param callback
+*/
+var discover = function (callback) {
+    log('Performing discovery')
+    var LAN = ip.address().substr(0, ip.address().lastIndexOf('.')) || ip.address();
+
+    var kettle = null;
+    // Scan over a range of IP addresses and execute a function each time the PORT is shown to be open.
+    for ( var i = 1; i <= 255; i++ ) {
+
+        // Scan local network
+        checkPort( PORT, LAN + '.' + i, function ( error, status, host, port ) {
+            debug('Found IP address ' + host)
+            if ( status == "open" ) {
+                // Check if found device is a kettle
+                checkForKettle( host, { state: status }, function (socket) {
+                    if (socket) {
+                        kettle = socket
+                        callback(null, kettle)
+                    } else if(i == 255 && !socket){
+                        debug( 'No IPs to be checked anymore')
+                        callback('Kettle not found :{', null);
+                    }
+                });
+            }
+        } );
     }
-    var ipAddresses = []
-    networkInterfaces.forEach(function(networkInterface) {
-      (networkInterface.neighbors || []).forEach(function(ip) {
-          ipAddresses.push(ip)
-          debug('Found IP address ' + ip)
-      })
-    })
-    if (0 === ipAddresses.length) {
-        return callback('No IP addresses to scan')
-    }
-    performScan(ipAddresses, callback)
-  })
 }
 
 module.exports = discover

--- a/lib/discover.js
+++ b/lib/discover.js
@@ -45,7 +45,7 @@ var checkForKettle = function(ip, portDetails, callback) {
  * @param callback2
  */
 var createConnection = function ( port, host, checkPort, callback ) {
-    var socket = new Socket(), status = null;
+    var socket = new Socket(), status = null, error = null;
 
     // Socket connection established, port is open
     socket.on( 'connect', function () {
@@ -58,8 +58,8 @@ var createConnection = function ( port, host, checkPort, callback ) {
     // When connection timeout destroy and return
     socket.on( 'timeout', function () {
         status = 'closed';
+        error = true;
         socket.destroy();
-        checkPort( true, status, host, callback);
     } );
 
     // On error, set status to closed
@@ -69,7 +69,7 @@ var createConnection = function ( port, host, checkPort, callback ) {
 
     // When a socket is closed
     socket.on( 'close', function ( ) {
-        checkPort( null, status, host, callback );
+        checkPort( error, status, host, callback );
     } );
 
     // Connect socket to host@port

--- a/lib/discover.js
+++ b/lib/discover.js
@@ -54,9 +54,11 @@ var checkPort = function ( port, host, callback ) {
     socket.on( 'timeout', function () {
         status = 'closed';
         socket.destroy();
+        callback( true, status, host, port);
     } );
     socket.on( 'error', function ( exception ) {
         status = 'closed';
+        callback( true, status, host, port);
     } );
     socket.on( 'close', function ( exception ) {
         callback( null, status, host, port );

--- a/lib/discover.js
+++ b/lib/discover.js
@@ -8,6 +8,7 @@ var Socket = require('net').Socket
 var PORT = 2000
 var HELLO_APP = 'HELLOAPP'
 var HELLO_KETTLE = 'HELLOKETTLE\n'
+var kettle = null;
 
 var checkForKettle = function(ip, portDetails, callback) {
     debug('Checking IP ' + ip + ' for kettles', portDetails.state)
@@ -36,13 +37,14 @@ var checkForKettle = function(ip, portDetails, callback) {
 }
 
 /**
- * This method looks a certain port on a host
- * and determines if it is open or not
+ * This method creates a socket connection to host@port and returns
+ * whether this device is listening on port or not.
  * @param port
  * @param host
- * @param callback
+ * @param checkPort
+ * @param callback2
  */
-var checkPort = function ( port, host, callback ) {
+var createConnection = function ( port, host, checkPort, callback ) {
     var socket = new Socket(), status = null;
 
     // Socket connection established, port is open
@@ -50,53 +52,87 @@ var checkPort = function ( port, host, callback ) {
         status = 'open';
         socket.end();
     } );
-    socket.setTimeout( 1500 );// If no response, assume port is not listening
+    // If no response, assume port is not listening
+    socket.setTimeout( 1500 );
+
+    // When connection timeout destroy and return
     socket.on( 'timeout', function () {
         status = 'closed';
         socket.destroy();
-        callback( true, status, host, port);
-    } );
-    socket.on( 'error', function ( exception ) {
-        status = 'closed';
-        callback( true, status, host, port);
-    } );
-    socket.on( 'close', function ( exception ) {
-        callback( null, status, host, port );
+        checkPort( true, status, host, callback);
     } );
 
+    // On error, set status to closed
+    socket.on( 'error', function ( ) {
+        status = 'closed';
+    } );
+
+    // When a socket is closed
+    socket.on( 'close', function ( ) {
+        checkPort( null, status, host, callback );
+    } );
+
+    // Connect socket to host@port
     socket.connect( port, host );
 }
 
 /**
-* This method loops over local interfaces and finds a list
-* of IP addresses within the same subnet
-* @param callback
-*/
-var discover = function (callback) {
-    log('Performing discovery')
-    var LAN = ip.address().substr(0, ip.address().lastIndexOf('.')) || ip.address();
+ * This method checks when a port is open whether it is a kettle,
+ * and when there are IPs left to check it returns nothing found if necessary
+ * @param error
+ * @param status
+ * @param host
+ * @param callback
+ */
+var checkPort = function ( error, status, host, callback ) {
+    debug('Found IP address ' + host)
 
-    var kettle = null;
-    // Scan over a range of IP addresses and execute a function each time the PORT is shown to be open.
-    for ( var i = 1; i <= 255; i++ ) {
+    // If port is open
+    if ( status === 'open' ) {
 
-        // Scan local network
-        checkPort( PORT, LAN + '.' + i, function ( error, status, host, port ) {
-            debug('Found IP address ' + host)
-            if ( status == "open" ) {
-                // Check if found device is a kettle
-                checkForKettle( host, { state: status }, function (socket) {
-                    if (socket) {
-                        kettle = socket
-                        callback(null, kettle)
-                    } else if(i == 255){
-                        debug( 'No IPs to be checked anymore')
-                        callback('Kettle not found :{', null);
-                    }
-                });
+        // Check if found device is a kettle
+        checkForKettle( host, { state: status }, function (socket) {
+
+            // Successfully created a socket to a kettle
+            if (socket) {
+                kettle = socket
+                callback(null, kettle)
             }
-        } );
+        });
+    }
+
+    // If we reached end of subnet and no kettle was fount
+    if(/255/i.test(host) && !kettle){
+        debug( 'No IPs to be checked anymore')
+        callback('Kettle not found :{', null)
     }
 }
 
-module.exports = discover
+/**
+ * This method loops over local interfaces and finds a list
+ * of IP addresses within the same subnet
+ * @param callback
+ */
+var discover = function (callback) {
+    log('Performing discovery')
+
+    // Create LAN address
+    var LAN = ip.address().substr(0, ip.address().lastIndexOf('.')) || ip.address();
+
+    // Set kettle to null as new discovery is started
+    kettle = null;
+
+    // Scan over a range of IP addresses and execute a function each time the PORT is shown to be open.
+    for ( var i = 0; i <= 255; i++ ) {
+        
+        // Scan local network
+        createConnection( PORT, LAN + '.' + i, checkPort, callback)
+    }
+}
+
+// Export all for testing purposes
+module.exports = {
+    discover: discover,
+    createConnection: createConnection,
+    checkPort: checkPort
+}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "colors": "^1.0.3",
     "debug": "^2.1.0",
-    "node-libnmap": "^0.1.12"
+    "ip": "^1.0.1"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",

--- a/test/lib/discover.js
+++ b/test/lib/discover.js
@@ -17,18 +17,18 @@ describe('Discovery', function() {
 
         it('If creating a socket succeeds', function(done) {
             var discover = proxyquire('../../lib/discover', {PORT: 80, LAN: '192.168.1.2'})
-            discover(function(error, status, host, port) {
+            discover(function(error, kettle) {
                 error.should.equal(null)
-                status.should.be.equal('closed')
+                kettle.should.be.equal('closed')
                 done()
             })
         })
 
         it('If there\'s no devices listening on port 2000 on the network', function(done) {
 
-            var discover = proxyquire('../../lib/discover')
-            discover(function(error, socket) {
-                should.not.exist(socket)
+            var discover = require('../../lib/discover')
+            discover(function(error, kettle) {
+                should.not.exist(kettle)
                 error.should.equal('Kettle not found :(')
                 done()
             })

--- a/test/lib/discover.js
+++ b/test/lib/discover.js
@@ -1,38 +1,79 @@
 'use strict';
-
-var proxyquire =  require('proxyquire')
-    , should = require('should')
+/* exported should*/
+var proxyquire =  require('proxyquire'),
+    should = require('should'),
+    ip = require('ip')
 
 describe('Discovery', function() {
 
     describe('Scan', function() {
 
         it('If creating a socket fails', function(done) {
-            var discover = proxyquire('../../lib/discover', {PORT: 0, LAN: 0})
+            var discover = proxyquire('../../lib/discover', {PORT: 0, LAN: 0} ).discover
             discover(function(error) {
-                error.should.equal(true)
+                error.should.equal('Kettle not found :{')
                 done()
             })
         })
 
-        it('If creating a socket succeeds', function(done) {
-            var discover = proxyquire('../../lib/discover', {PORT: 80, LAN: '192.168.1.2'})
-            discover(function(error, kettle) {
-                error.should.equal(null)
-                kettle.should.be.equal('closed')
+        it('If a socket is timing out', function(done) {
+            var createConnection = require('../../lib/discover' ).createConnection
+            //port, host, callback1, callback2
+            createConnection(2000, '192.168.1.2', function(error, status) {
+                error.should.equal(true)
+                status.should.equal('closed')
+                done()
+            })
+        })
+
+        it('If a device is not listening on port 2000', function(done) {
+            var createConnection = require('../../lib/discover' ).createConnection
+            //port, host, callback1, callback2
+            createConnection(2000, ip.address(), function(error, status) {
+                should.not.exist(error)
+                status.should.equal('closed')
+                done()
+            })
+        })
+
+        it('If a device is listening on a port', function(done) {
+            var createConnection = require('../../lib/discover' ).createConnection
+            createConnection(53, '8.8.8.8', function(error, status) {
+                should.not.exist(error)
+                status.should.equal('open')
+                done()
+            })
+        })
+
+        it('If a port is closed and no ports left to scan', function(done) {
+            var checkPort = require('../../lib/discover' ).checkPort
+            //error, status, host, callback
+            checkPort(false, 'closed', '192.168.1.255', function(error, kettle) {
+                should.not.exist(kettle)
+                error.should.equal('Kettle not found :{')
+                done()
+            })
+        })
+
+        it('If there are open ports, but it is no kettle', function(done) {
+            var checkPort = require('../../lib/discover' ).checkPort
+            //error, status, host, callback
+            checkPort(false, 'open', '192.168.1.255', function(error, kettle) {
+                should.not.exist(kettle)
+                error.should.equal('Kettle not found :{')
                 done()
             })
         })
 
         it('If there\'s no devices listening on port 2000 on the network', function(done) {
-
-            var discover = require('../../lib/discover')
+            var discover = require('../../lib/discover' ).discover
             discover(function(error, kettle) {
                 should.not.exist(kettle)
-                error.should.equal('Kettle not found :(')
+                error.should.equal('Kettle not found :{')
                 done()
             })
         })
+
 
     })
 

--- a/test/lib/discover.js
+++ b/test/lib/discover.js
@@ -8,16 +8,16 @@ describe('Discovery', function() {
     describe('Scan', function() {
 
         it('If creating a socket fails', function(done) {
-            var checkPort = proxyquire('../../lib/checkPort', {PORT: 0, LAN: 0})
-            checkPort(function(error) {
+            var discover = proxyquire('../../lib/discover', {PORT: 0, LAN: 0})
+            discover(function(error) {
                 error.should.equal(true)
                 done()
             })
         })
 
         it('If creating a socket succeeds', function(done) {
-            var checkPort = proxyquire('../../lib/checkPort', {PORT: 80, LAN: '192.168.1.2'})
-            checkPort(function(error, status, host, port) {
+            var discover = proxyquire('../../lib/discover', {PORT: 80, LAN: '192.168.1.2'})
+            discover(function(error, status, host, port) {
                 error.should.equal(null)
                 status.should.be.equal('closed')
                 done()

--- a/test/lib/discover.js
+++ b/test/lib/discover.js
@@ -1,115 +1,39 @@
 'use strict';
 
 var proxyquire =  require('proxyquire')
-  , should = require('should')
+    , should = require('should')
 
 describe('Discovery', function() {
-    
-    var errorMessage = 'ERROR'
-    
-    it('Returns an error with `nmap` error', function(done) {
-        var nMap = {
-            nmap: function(method, options, callback) {
-                method.should.equal('discover')
-                options.should.eql({})
-                callback(errorMessage)
-            }
-        }
-        var discover = proxyquire('../../lib/discover', { 'node-libnmap': nMap, net: {} })
-        discover(function(error, socket) {
-            should.not.exist(socket)
-            error.should.equal(errorMessage)
-            done()
-        })
-        
-    })
-    
-    it('Errors if there\'s no IP addresses to scan', function(done) {
-        var nMap = {
-            nmap: function(method, options, callback) {
-                method.should.equal('discover')
-                options.should.eql({})
-                callback(null, [])
-            }
-        }
-        var discover = proxyquire('../../lib/discover', { 'node-libnmap': nMap, net: {} })
-        discover(function(error, socket) {
-            should.not.exist(socket)
-            error.should.equal('No IP addresses to scan')
-            done()
-        })
-        
-    })
-    
+
     describe('Scan', function() {
-    
-        var ipAddresses = [ '192.168.0.1' ]
-        
-        it('Errors if nmap scan fails', function(done) {
-            var nmapCalls = 0
-            var nMap = {
-                nmap: function(method, options, callback) {
-                    ++nmapCalls
-                    if (1 === nmapCalls) {
-                        return callback(null, [ { neighbors: ipAddresses } ])
-                    }
-                    method.should.equal('scan')
-                    options.should.eql({ range: ipAddresses, ports: 2000 })
-                    callback(errorMessage)
-                }
-            }
-            var discover = proxyquire('../../lib/discover', { 'node-libnmap': nMap, net: {} })
-            discover(function(error, socket) {
-                should.not.exist(socket)
-                error.should.equal(errorMessage)
+
+        it('If creating a socket fails', function(done) {
+            var checkPort = proxyquire('../../lib/checkPort', {PORT: 0, LAN: 0})
+            checkPort(function(error) {
+                error.should.equal(true)
                 done()
             })
         })
-        
-        it('If there\'s no reported devices listening on 2000 discovery fails', function(done) {
-            var nmapCalls = 0
-            var nMap = {
-                nmap: function(method, options, callback) {
-                    ++nmapCalls
-                    if (1 === nmapCalls) {
-                        return callback(null, [ { neighbors: ipAddresses } ])
-                    }
-                    callback(null, [])
-                }
-            }
-            var discover = proxyquire('../../lib/discover', { 'node-libnmap': nMap, net: {} })
-            discover(function(error, socket) {
-                should.not.exist(socket)
-                error.should.equal('No devices listening on port 2000')
+
+        it('If creating a socket succeeds', function(done) {
+            var checkPort = proxyquire('../../lib/checkPort', {PORT: 80, LAN: '192.168.1.2'})
+            checkPort(function(error, status, host, port) {
+                error.should.equal(null)
+                status.should.be.equal('closed')
                 done()
             })
         })
-        
-        it('Fails discovery if devices listening on port 2000 are closed', function(done) {
-            var nmapCalls = 0
-            var nMap = {
-                nmap: function(method, options, callback) {
-                    ++nmapCalls
-                    if (1 === nmapCalls) {
-                        return callback(null, [ { neighbors: ipAddresses } ])
-                    }
-                    callback(null, [ [ { ip: '192.168.0.1', ports: [ { state: 'closed' } ] } ] ])
-                }
-            }
-            var discover = proxyquire('../../lib/discover', { 'node-libnmap': nMap, net: {} })
+
+        it('If there\'s no devices listening on port 2000 on the network', function(done) {
+
+            var discover = proxyquire('../../lib/discover')
             discover(function(error, socket) {
                 should.not.exist(socket)
                 error.should.equal('Kettle not found :(')
                 done()
             })
         })
-        
+
     })
-    
-    describe('Socket discovery', function() {
-        
-        
-    })
-    
-    
+
 })


### PR DESCRIPTION
Replaced functionality provided by node-nmap, by using a regular TCP
scan. As node-nmap requires a binary (nmap), which can not be used on
the platform we deploy ikettle.js on, overall it is better to use modules that do not require binaries to increase cross-platform support.
